### PR TITLE
not use ssl for connecting logproxy by default

### DIFF
--- a/deployer/src/main/resources/example/ob-instance.properties
+++ b/deployer/src/main/resources/example/ob-instance.properties
@@ -6,7 +6,7 @@ canal.instance.oceanbase.startTimestamp=0
 
 # ob log proxy info
 canal.instance.oceanbase.logproxy.address=127.0.0.1:2983
-canal.instance.oceanbase.logproxy.sslEnabled=true
+canal.instance.oceanbase.logproxy.sslEnabled=false
 canal.instance.oceanbase.logproxy.serverCert=../conf/${canal.instance.destination:}/ca.crt
 canal.instance.oceanbase.logproxy.clientCert=../conf/${canal.instance.destination:}/client.crt
 canal.instance.oceanbase.logproxy.clientKey=../conf/${canal.instance.destination:}/client.key


### PR DESCRIPTION
Ensure the default behavior is consistent with logproxy.