### PR TITLE
fix: support libobcdc 4.x

### DIFF
--- a/deployer/src/main/resources/example/ob-instance.properties
+++ b/deployer/src/main/resources/example/ob-instance.properties
@@ -18,14 +18,14 @@ canal.instance.oceanbase.logproxy.clientCert=../conf/${canal.instance.destinatio
 canal.instance.oceanbase.logproxy.clientKey=../conf/${canal.instance.destination:}/client.key
 canal.instance.oceanbase.logproxy.clientId=
 
-# tenant name
-canal.instance.oceanbase.tenant=sys
+# tenant name, libobcdc 4.x only supports to subscribe clog of non-sys tenant
+canal.instance.oceanbase.tenant=test
 # exclude tenant name in target schema name
 canal.instance.parser.excludeTenantInDbName=true
 
-# table regex, format: [tenant].[database].[table]
-canal.instance.filter.regex=sys.*.*
-# table black regex
+# table white regex, seperated by comma, format: [tenant].[database].[table]
+canal.instance.filter.regex=test.*.*
+# table black regex, seperated by comma, format: [tenant].[database].[table]
 #canal.instance.filter.black.regex=mysql\\.slave_.*
 # table field filter(format: schema1.tableName1:field1/field2,schema2.tableName2:field1/field2)
 #canal.instance.filter.field=test1.t_product:id/subject/keywords,test2.t_company:id/name/contact/ch

--- a/deployer/src/main/resources/spring/ob-default-instance.xml
+++ b/deployer/src/main/resources/spring/ob-default-instance.xml
@@ -59,7 +59,6 @@
                 <property name="username" value="${canal.instance.oceanbase.username}"/>
                 <property name="password" value="${canal.instance.oceanbase.password}"/>
                 <property name="startTimestamp" value="${canal.instance.oceanbase.startTimestamp:0}"/>
-                <property name="tableWhiteList" value="${canal.instance.filter.regex}"/>
                 <property name="clusterUrl" value="${canal.instance.oceanbase.clusterUrl}"/>
                 <property name="timezone" value="${canal.instance.oceanbase.timezone}"/>
                 <property name="workingMode" value="${canal.instance.oceanbase.workingMode}"/>

--- a/deployer/src/main/resources/spring/ob-file-instance.xml
+++ b/deployer/src/main/resources/spring/ob-file-instance.xml
@@ -45,7 +45,6 @@
                 <property name="username" value="${canal.instance.oceanbase.username}"/>
                 <property name="password" value="${canal.instance.oceanbase.password}"/>
                 <property name="startTimestamp" value="${canal.instance.oceanbase.startTimestamp:0}"/>
-                <property name="tableWhiteList" value="${canal.instance.filter.regex}"/>
                 <property name="clusterUrl" value="${canal.instance.oceanbase.clusterUrl}"/>
                 <property name="timezone" value="${canal.instance.oceanbase.timezone}"/>
                 <property name="workingMode" value="${canal.instance.oceanbase.workingMode}"/>

--- a/deployer/src/main/resources/spring/ob-memory-instance.xml
+++ b/deployer/src/main/resources/spring/ob-memory-instance.xml
@@ -33,7 +33,6 @@
                 <property name="username" value="${canal.instance.oceanbase.username}"/>
                 <property name="password" value="${canal.instance.oceanbase.password}"/>
                 <property name="startTimestamp" value="${canal.instance.oceanbase.startTimestamp:0}"/>
-                <property name="tableWhiteList" value="${canal.instance.filter.regex}"/>
                 <property name="clusterUrl" value="${canal.instance.oceanbase.clusterUrl}"/>
                 <property name="timezone" value="${canal.instance.oceanbase.timezone}"/>
                 <property name="workingMode" value="${canal.instance.oceanbase.workingMode}"/>

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/oceanbase/logproxy/LogProxyEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/oceanbase/logproxy/LogProxyEventParser.java
@@ -42,6 +42,9 @@ public class LogProxyEventParser extends AbstractOceanBaseEventParser<LogMessage
 
     @Override
     protected OceanBaseConnection buildOceanBaseConnection() {
+        // libobcdc 4.x only supports to subscribe clog of entire tenant
+        logProxyConfig.setTableWhiteList(String.format("%s.*.*", tenant));
+
         // priority of start position source: position manager > properties file > zero value
         EntryPosition startPosition = findStartPosition();
         if (startPosition != null) {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Close #23 

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

Two modifications:
1. Always subscribe clog with whitelist `tenant.*.*` in fnmatch format.
2. Filter dml by db and table name. Users can set whitelist and blacklist by regex value `canal.instance.filter.regex` and `canal.instance.filter.black.regex` in format `[tenant].[db].[table]` seperated by comma.
